### PR TITLE
Fix bug related to blueprint sandboxes migration from 2.x to 3.x

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -110,7 +110,7 @@ do
 	end
 	local function update(event)
 		---@cast event OnRuntimeModSettingChanged
-		local p = game.players[event.player_index]
+		local p = event.player_index and game.players[event.player_index]
 		if not p or not p.valid then return end
 		if not map[event.setting] then return end
 		if not ini[p.index] then ini[p.index] = {} end


### PR DESCRIPTION
This fixes the relevant discussion: https://mods.factorio.com/mod/folk-shuttle/discussion/681284547210605ec45a8a2f

The game crashes with unrecoverable error after the blueprint sandboxes 2.x is has been updated to 3.x